### PR TITLE
feat(renderCrumbs): add hideNoPath.

### DIFF
--- a/dist/breadcrumbs.js
+++ b/dist/breadcrumbs.js
@@ -94,8 +94,11 @@ var renderCrumbs = exports.renderCrumbs = function renderCrumbs(_ref2) {
     var params = _ref2.params;
     var createLink = _ref2.createLink;
     var resolver = _ref2.resolver;
+    var hideNoPath = _ref2.hideNoPath;
 
-    var crumbs = (0, _utils.on)(routes).filter((0, _utils.not)((0, _utils.where)((0, _utils.pluck)('breadcrumbIgnore'), (0, _utils.isEqualTo)(true)))).map(toCrumb({ params: params, createLink: createLink, resolver: resolver })).reduce((0, _utils.join)(createSeparator), []);
+    var crumbs = (0, _utils.on)(routes).filter((0, _utils.not)((0, _utils.where)((0, _utils.pluck)('breadcrumbIgnore'), (0, _utils.isEqualTo)(true)))).filter(function (route) {
+        return hideNoPath ? (0, _utils.pluck)('path')(route) : true;
+    }).map(toCrumb({ params: params, createLink: createLink, resolver: resolver })).reduce((0, _utils.join)(createSeparator), []);
 
     return (0, _utils.on)(prefixElements).concat(crumbs).concat((0, _utils.on)(suffixElements));
 };
@@ -118,7 +121,8 @@ Breadcrumbs.defaultProps = {
     createLink: defaultLink,
     createSeparator: defaultSeparator,
     prefixElements: [],
-    suffixElements: []
+    suffixElements: [],
+    hideNoPath: false
 };
 
 Breadcrumbs.propTypes = {
@@ -130,7 +134,8 @@ Breadcrumbs.propTypes = {
     className: _react.PropTypes.string,
     wrappingComponent: _react.PropTypes.string,
     prefixElements: _react.PropTypes.oneOfType([_react.PropTypes.arrayOf(_react.PropTypes.element), _react.PropTypes.element]),
-    suffixElements: _react.PropTypes.oneOfType([_react.PropTypes.arrayOf(_react.PropTypes.element), _react.PropTypes.element])
+    suffixElements: _react.PropTypes.oneOfType([_react.PropTypes.arrayOf(_react.PropTypes.element), _react.PropTypes.element]),
+    hideNoPath: _react.PropTypes.bool
 };
 
 exports.default = Breadcrumbs;

--- a/src/breadcrumbs.js
+++ b/src/breadcrumbs.js
@@ -48,10 +48,12 @@ export const renderCrumbs = ({
     suffixElements,
     params,
     createLink,
-    resolver
+    resolver,
+    hideNoPath
     }) => {
     const crumbs = on(routes)
         .filter(not(where(pluck('breadcrumbIgnore'), isEqualTo(true))))
+        .filter((route) => hideNoPath ? pluck('path')(route) : true)
         .map(toCrumb({ params, createLink, resolver }))
         .reduce(join(createSeparator), []);
 
@@ -71,7 +73,8 @@ Breadcrumbs.defaultProps = {
     createLink: defaultLink,
     createSeparator: defaultSeparator,
     prefixElements: [],
-    suffixElements: []
+    suffixElements: [],
+    hideNoPath: false
 };
 
 Breadcrumbs.propTypes = {
@@ -83,7 +86,8 @@ Breadcrumbs.propTypes = {
     className: PT.string,
     wrappingComponent: PT.string,
     prefixElements: PT.oneOfType([PT.arrayOf(PT.element), PT.element]),
-    suffixElements: PT.oneOfType([PT.arrayOf(PT.element), PT.element])
+    suffixElements: PT.oneOfType([PT.arrayOf(PT.element), PT.element]),
+    hideNoPath: PT.bool
 };
 
 export default Breadcrumbs;

--- a/test/breadcrumbs-test.js
+++ b/test/breadcrumbs-test.js
@@ -192,6 +192,30 @@ describe('Breadcrumbs', () => {
             expect(res[2].type.displayName).to.equal('Link');
         });
 
+        it('should ignore routes without path', () => {
+            const RouteWithEmptyPath = {
+                ...defaultRoute,
+                path: undefined
+            };
+
+            const res = Func.renderCrumbs({
+                ...defaultProps,
+                routes: [
+                    { ...RouteWithEmptyPath },
+                    { ...defaultRoute },
+                    { ...RouteWithEmptyPath },
+                    { ...defaultRoute },
+                    { ...RouteWithEmptyPath }
+                ],
+                hideNoPath: true
+            });
+
+            expect(res.length).to.equal(3); // Link - Separator - Link
+            expect(res[0].type.displayName).to.equal('Link');
+            expect(res[1].type).to.equal('span');
+            expect(res[2].type.displayName).to.equal('Link');
+        });
+
         it('should append prefixElement to the front, and allow for React.element as prop', () => {
             const res = Func.renderCrumbs({
                 ...defaultProps,


### PR DESCRIPTION
In some cases React-Router may not have a path in the parent node. This is a valid use case when you want to wrap components with other components but they are not true routes. For these you can use the "hideNoPath" property (default=true) to either hide or show these in the breadcrumbs.

For example react-redux connect wrap component with empty path.