### PR TITLE
Added modification to account for missing routes

### DIFF
--- a/dist/breadcrumbs.js
+++ b/dist/breadcrumbs.js
@@ -107,6 +107,9 @@ function Breadcrumbs(_ref3) {
     var props = _objectWithoutProperties(_ref3, ['className', 'wrappingComponent']);
 
     var crumbs = renderCrumbs(props);
+
+    if (crumbs.length === 0) return null;
+
     return _react2.default.createElement(wrappingComponent, { className: className }, crumbs);
 }
 

--- a/src/breadcrumbs.js
+++ b/src/breadcrumbs.js
@@ -60,6 +60,9 @@ export const renderCrumbs = ({
 
 function Breadcrumbs({ className, wrappingComponent, ...props }) {
     const crumbs = renderCrumbs(props);
+
+    if (crumbs.length === 0) return null;
+
     return React.createElement(wrappingComponent, { className }, crumbs);
 }
 

--- a/test/breadcrumbs-test.js
+++ b/test/breadcrumbs-test.js
@@ -248,8 +248,16 @@ describe('Breadcrumbs', () => {
     });
 
     describe('Component', () => {
+        it('should return a null component if there are no crumbs (or routes)', () => {
+            const routes = [{ ...defaultRoute, breadcrumbIgnore: true }];
+            const wrapper = shallow(<Breadcrumbs routes={routes} />);
+
+            expect(wrapper.node).to.equal(null);
+        });
+
         it('should render div as default wrappingComponent', () => {
-            const wrapper = shallow(<Breadcrumbs routes={[]} />);
+            const routes = [{ ...defaultRoute }];
+            const wrapper = shallow(<Breadcrumbs routes={routes} />);
 
             const wrappingComponent = wrapper.find('div.breadcrumbs');
             expect(wrappingComponent.length).to.equal(1);
@@ -257,7 +265,8 @@ describe('Breadcrumbs', () => {
         });
 
         it('should respect wrappingComponent and className props', () => {
-            const wrapper = shallow(<Breadcrumbs routes={[]} wrappingComponent="article" className="custom" />);
+            const routes = [{ ...defaultRoute }];
+            const wrapper = shallow(<Breadcrumbs routes={routes} wrappingComponent="article" className="custom" />);
 
             const wrappingComponent = wrapper.find('article.custom');
             expect(wrappingComponent.length).to.equal(1);


### PR DESCRIPTION
In our company's current project, we have a routing scenario where a page may be accessed that has all routes ignored for breadcrumbs or no breadcrumbs could be rendered.

The original behavior was to render the wrappingComponent anyways, with the className, and the empty crumbs.

If we have empty `crumbs`, we do not want to render `<Breadcrumbs />`. But, because we cannot check for the length of `crumbs` externally without iterating over the routes and checking where `breadcrumbsIgnore === true`, we are proposing to simply return nothing, or `null`, where there are no `crumbs` returned.