### PR TITLE
Support optional parameters

### DIFF
--- a/src/breadcrumbs.js
+++ b/src/breadcrumbs.js
@@ -1,5 +1,5 @@
 import React, { PropTypes as PT } from 'react';
-import { Link } from 'react-router';
+import { Link, formatPattern } from 'react-router';
 import * as RouterProps from './router-props';
 import { on, not, where, pluck, isEqualTo, join, lastOf } from './utils';
 
@@ -28,7 +28,7 @@ export const createHref = (routePath, params) => {
         .join('')
         .replace(/\/\/+/g, '/');
 
-    return paramReplace(link, params);
+    return formatPattern(link, params);
 };
 
 export const toCrumb = ({ params, createLink, resolver }) =>

--- a/test/breadcrumbs-test.js
+++ b/test/breadcrumbs-test.js
@@ -149,14 +149,14 @@ describe('Breadcrumbs', () => {
         it('should replace keys with the params provided', () => {
             const res = Func.createHref([
                 { breadcrumbLink: ':item1' },
-                { breadcrumbLink: ':item2' },
+                { breadcrumbLink: '(:item2)' },
                 { breadcrumbLink: ':item3' }
             ], {
                 item1: 'val1',
                 item3: 'val3'
             });
 
-            expect(res).to.equal('/val1/item2/val3');
+            expect(res).to.equal('/val1/val3');
         });
 
         it('should handle optional params with values present', () => {

--- a/test/breadcrumbs-test.js
+++ b/test/breadcrumbs-test.js
@@ -93,6 +93,15 @@ describe('Breadcrumbs', () => {
             expect(resolver.calledWithExactly(':param1', 'value1', routePath, route)).to.equal(true);
         });
 
+        it('should call resolver with text, param-replaced-text, routepath and route (optional param)', () => {
+            const resolver = spy();
+            const route = { ...defaultRoute, breadcrumbName: ':param1', breadcrumbLink: 'path(/:param1)' };
+            const routePath = [{ ...route }, route];
+            Func.createText(routePath, { param1: 'value1' }, resolver);
+
+            expect(resolver.calledWithExactly(':param1', 'value1', routePath, route)).to.equal(true);
+        });
+
         it('should use breadcrumbName, then route.name then route.component.name for text resolution', () => {
             const textResolver = (a) => a;
             const componentNameTest = [undefined, { component: { name: 'componentname' } }];
@@ -148,6 +157,24 @@ describe('Breadcrumbs', () => {
             });
 
             expect(res).to.equal('/val1/item2/val3');
+        });
+
+        it('should handle optional params with values present', () => {
+            const res = Func.createHref([
+                { breadcrumbLink: 'path(/:item1)' },
+            ], {
+                item1: 'val1',
+            });
+
+            expect(res).to.equal('/path/val1');
+        });
+        it('should handle optional params with values missing', () => {
+            const res = Func.createHref([
+                { breadcrumbLink: 'path(/:item1)' },
+            ], {
+            });
+
+            expect(res).to.equal('/path');
         });
     });
     describe('_toCrumbs', () => {


### PR DESCRIPTION
Fixes #224 

Format the href using the react-router formatPattern method.

This is a **BREAKING** change as shown by the required change to the tests. Required parameters that are not present will now throw an invariant exception rather than substituting the key in. The old behavior could be restored by duplicating the formatPattern code and modifying it appropriately but this would have the downside of allow them to become out of sync again. I am open to suggestions on how to restore the old functionality if needed.